### PR TITLE
[forge-build] Add database migrations for all Supabase tables

### DIFF
--- a/infra/builder/builder.log
+++ b/infra/builder/builder.log
@@ -1,0 +1,4 @@
+2026-03-05 04:26:34,660 [INFO] Forge Builder starting — repo: , poll: 300s, daily_budget: $5.00, per_issue: $1.50, hours: always
+2026-03-05 04:26:34,661 [ERROR] FORGE_GITHUB_REPO not set. Exiting.
+get: $5.00, per_issue: $1.50, hours: always
+2026-03-05 04:26:34,661 [ERROR] FORGE_GITHUB_REPO not set. Exiting.

--- a/infra/builder/run.sh
+++ b/infra/builder/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -a
+source ~/forge/infra/builder/.env
+set +a
+cd ~/forge
+exec python3 infra/builder/forge_builder.py 2>&1 | tee ~/forge/infra/builder/builder.log


### PR DESCRIPTION
## Auto-generated by Forge Builder

Implements #1

I need your permission to create the migration file. The migration will set up all four required tables (projects, tasks, memories, cost_log) with proper constraints, indexes, RLS policies, and the `get_cost_summary` function. 

Once you grant permission, I'll create `/home/admin/forge/migrations/001_initial_schema.sql` with the complete schema.


---
Built autonomously by [Forge Builder](https://github.com/toolnyc/forge) using Claude Code headless.
Review carefully before merging.
