### PR TITLE
[forge-build] Add pytest setup with basic tests for agent lifecycle and cost estimation

### DIFF
--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -27,6 +27,16 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Shared pytest fixtures for Forge orchestrator tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_db():
+    """Return a mock Supabase client with chainable query builder."""
+    db = MagicMock()
+
+    # Make table() return a builder that supports chaining
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.insert.return_value = builder
+    builder.update.return_value = builder
+    builder.eq.return_value = builder
+    builder.like.return_value = builder
+    builder.order.return_value = builder
+    builder.limit.return_value = builder
+    builder.single.return_value = builder
+    builder.execute.return_value = MagicMock(data=[])
+
+    db.table.return_value = builder
+    return db
+
+
+@pytest.fixture
+def patch_db(mock_db):
+    """Patch get_db() to return mock_db for the duration of the test."""
+    with patch("forge.db.get_db", return_value=mock_db):
+        yield mock_db

--- a/orchestrator/tests/test_cli.py
+++ b/orchestrator/tests/test_cli.py
@@ -1,0 +1,76 @@
+"""Tests for the Forge CLI using Typer's CliRunner."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from forge.cli import app
+
+
+runner = CliRunner()
+
+
+def _make_db_mock(tasks_data=None):
+    db = MagicMock()
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.update.return_value = builder
+    builder.insert.return_value = builder
+    builder.eq.return_value = builder
+    builder.order.return_value = builder
+    builder.limit.return_value = builder
+    builder.single.return_value = builder
+    builder.like.return_value = builder
+    builder.execute.return_value = MagicMock(data=tasks_data or [])
+    db.table.return_value = builder
+    return db
+
+
+def test_help():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "forge" in result.output.lower() or "Usage" in result.output
+
+
+def test_tasks_outputs_table():
+    tasks_data = [
+        {
+            "id": "abc12345-0000-0000-0000-000000000000",
+            "title": "Research: test topic",
+            "status": "complete",
+            "model_used": "claude-sonnet-4-6",
+            "cost_usd": 0.0012,
+            "created_at": "2026-03-05T10:00:00",
+        }
+    ]
+    db_mock = _make_db_mock(tasks_data)
+
+    with patch("forge.cli.get_db", return_value=db_mock):
+        result = runner.invoke(app, ["tasks"])
+
+    assert result.exit_code == 0
+    assert "Research: test topic" in result.output
+    assert "complete" in result.output
+
+
+def test_tasks_empty_db():
+    db_mock = _make_db_mock([])
+
+    with patch("forge.cli.get_db", return_value=db_mock):
+        result = runner.invoke(app, ["tasks"])
+
+    assert result.exit_code == 0
+    assert "Forge Tasks" in result.output
+
+
+def test_tasks_status_filter():
+    db_mock = _make_db_mock([])
+
+    with patch("forge.cli.get_db", return_value=db_mock):
+        result = runner.invoke(app, ["tasks", "--status", "pending"])
+
+    assert result.exit_code == 0
+    db_mock.table.return_value.eq.assert_called_with("status", "pending")

--- a/orchestrator/tests/test_cost_estimation.py
+++ b/orchestrator/tests/test_cost_estimation.py
@@ -1,0 +1,54 @@
+"""Tests for ForgeAgent._estimate_cost()."""
+
+from __future__ import annotations
+
+import pytest
+
+from forge.agents.base import ForgeAgent
+
+
+class TestEstimateCost:
+    def test_sonnet_known_rate(self):
+        # 1M in + 1M out = $3.00 + $15.00 = $18.00
+        cost = ForgeAgent._estimate_cost(1_000_000, 1_000_000, "claude-sonnet-4-6")
+        assert cost == pytest.approx(18.0)
+
+    def test_haiku_known_rate(self):
+        # 1M in + 1M out = $0.80 + $4.00 = $4.80
+        cost = ForgeAgent._estimate_cost(1_000_000, 1_000_000, "claude-haiku-4-5")
+        assert cost == pytest.approx(4.80)
+
+    def test_opus_known_rate(self):
+        # 1M in + 1M out = $15.00 + $75.00 = $90.00
+        cost = ForgeAgent._estimate_cost(1_000_000, 1_000_000, "claude-opus-4-6")
+        assert cost == pytest.approx(90.0)
+
+    def test_gpt4o_known_rate(self):
+        # 1M in + 1M out = $2.50 + $10.00 = $12.50
+        cost = ForgeAgent._estimate_cost(1_000_000, 1_000_000, "gpt-4o")
+        assert cost == pytest.approx(12.50)
+
+    def test_zero_tokens(self):
+        cost = ForgeAgent._estimate_cost(0, 0, "claude-sonnet-4-6")
+        assert cost == 0.0
+
+    def test_unknown_model_uses_default_rate(self):
+        # Unknown model should fall back to sonnet rates: $3/$15 per 1M
+        cost_unknown = ForgeAgent._estimate_cost(100_000, 50_000, "some-future-model")
+        cost_sonnet = ForgeAgent._estimate_cost(100_000, 50_000, "claude-sonnet-4-6")
+        assert cost_unknown == cost_sonnet
+
+    def test_realistic_token_counts(self):
+        # 2000 in, 500 out with haiku
+        # = 2000 * 0.80/1e6 + 500 * 4.0/1e6
+        # = 0.0000016 + 0.000002 = 0.0000036
+        cost = ForgeAgent._estimate_cost(2000, 500, "claude-haiku-4-5")
+        assert cost == pytest.approx(0.0016 / 1000 + 0.002 / 1000, rel=1e-5)
+
+    def test_only_input_tokens(self):
+        cost = ForgeAgent._estimate_cost(1_000_000, 0, "claude-sonnet-4-6")
+        assert cost == pytest.approx(3.0)
+
+    def test_only_output_tokens(self):
+        cost = ForgeAgent._estimate_cost(0, 1_000_000, "claude-sonnet-4-6")
+        assert cost == pytest.approx(15.0)

--- a/orchestrator/tests/test_task_lifecycle.py
+++ b/orchestrator/tests/test_task_lifecycle.py
@@ -1,0 +1,113 @@
+"""Tests for ForgeAgent.run_task() lifecycle and cost logging."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from forge.agents.base import ForgeAgent
+
+
+def _make_agent_mock(response: str = "result", tokens_in: int = 100, tokens_out: int = 50):
+    """Build a minimal Pydantic AI agent mock."""
+    usage = MagicMock()
+    usage.request_tokens = tokens_in
+    usage.response_tokens = tokens_out
+
+    result = MagicMock()
+    result.output = response
+    result.all_messages_json.return_value = "[]"
+    result.usage.return_value = usage
+
+    agent = MagicMock()
+    agent.run = AsyncMock(return_value=result)
+    return agent
+
+
+def _make_db_mock():
+    """Supabase client mock with chainable builder."""
+    db = MagicMock()
+    builder = MagicMock()
+    builder.select.return_value = builder
+    builder.insert.return_value = builder
+    builder.update.return_value = builder
+    builder.eq.return_value = builder
+    builder.single.return_value = builder
+    builder.execute.return_value = MagicMock(data=None)
+    db.table.return_value = builder
+    return db
+
+
+@pytest.fixture
+def db_mock():
+    return _make_db_mock()
+
+
+@pytest.fixture
+def forge_agent(db_mock):
+    agent_mock = _make_agent_mock()
+    fa = ForgeAgent(name="test_agent", agent=agent_mock)
+    with patch("forge.agents.base.get_db", return_value=db_mock):
+        yield fa, db_mock
+
+
+@pytest.mark.asyncio
+async def test_run_task_marks_running_then_complete(forge_agent):
+    fa, db = forge_agent
+    task_id = "task-123"
+
+    with patch("forge.agents.base.get_db", return_value=db):
+        await fa.run_task(task_id=task_id, prompt="do a thing")
+
+    # Collect all update() calls (chained as .update(...).eq(...).execute())
+    update_calls = [call.args[0] for call in db.table.return_value.update.call_args_list]
+
+    statuses = [c.get("status") for c in update_calls if "status" in c]
+    assert "running" in statuses
+    assert "complete" in statuses
+
+
+@pytest.mark.asyncio
+async def test_run_task_failed_on_agent_error(forge_agent):
+    fa, db = forge_agent
+    fa.agent.run = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch("forge.agents.base.get_db", return_value=db):
+        with pytest.raises(RuntimeError, match="boom"):
+            await fa.run_task(task_id="task-err", prompt="fail please")
+
+    update_calls = [call.args[0] for call in db.table.return_value.update.call_args_list]
+    statuses = [c.get("status") for c in update_calls if "status" in c]
+    assert "failed" in statuses
+
+    # Error message stored in output
+    outputs = [c.get("output") for c in update_calls if "output" in c]
+    assert any("boom" in str(o) for o in outputs)
+
+
+@pytest.mark.asyncio
+async def test_run_task_logs_cost(forge_agent):
+    fa, db = forge_agent
+
+    with patch("forge.agents.base.get_db", return_value=db):
+        await fa.run_task(task_id="task-cost", prompt="log my cost")
+
+    # cost_log insert should have been called
+    insert_calls = [call.args[0] for call in db.table.return_value.insert.call_args_list]
+    assert len(insert_calls) >= 1
+    cost_entry = insert_calls[0]
+    assert "cost_usd" in cost_entry
+    assert cost_entry["cost_usd"] >= 0
+    assert "input_tokens" in cost_entry
+    assert "output_tokens" in cost_entry
+
+
+@pytest.mark.asyncio
+async def test_run_task_returns_output(forge_agent):
+    fa, db = forge_agent
+
+    with patch("forge.agents.base.get_db", return_value=db):
+        result = await fa.run_task(task_id="task-out", prompt="give output")
+
+    assert result["response"] == "result"


### PR DESCRIPTION
## Auto-generated by Forge Builder

Implements #4

All done. Here's a summary of what was implemented:

**`pyproject.toml`** — Added `[project.optional-dependencies] dev = [pytest, pytest-asyncio]` and `[tool.pytest.ini_options]` with `asyncio_mode = "auto"` and `testpaths = ["tests"]`.

**`orchestrator/tests/`** — New directory with:

- `__init__.py` — empty package marker
- `conftest.py` — `mock_db` and `patch_db` fixtures with chainable Supabase builder mock
- `test_cost_estimation.py` — 8 tests covering all 4 known models, zero tokens, unknown model fallback, realistic counts, and input/output-only scenarios
- `test_task_lifecycle.py` — 4 tests: status transitions (running→complete), failed task handling (status=failed + error in output), cost_log insert verified, return value check
- `test_cli.py` — 4 tests: `--help` exits 0, `tasks` renders a table with data, empty DB renders table header, `--status` filter calls `.eq()` correctly

Run with: `uv run pytest` (from `orchestrator/`) or install dev deps first: `uv pip install -e ".[dev]"` then `pytest`.


---
Built autonomously by [Forge Builder](https://github.com/toolnyc/forge) using Claude Code headless.
Review carefully before merging.
